### PR TITLE
fix(api): return correct location per item based on language

### DIFF
--- a/api/app/Http/Resources/ItemResource.php
+++ b/api/app/Http/Resources/ItemResource.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Resources;
 
+use App\Models\Location;
+use App\Services\GooglePlaces;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -21,6 +23,13 @@ class ItemResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
+        $language = $request->getPreferredLanguage(GooglePlaces::SUPPORTED_LANGUAGES);
+        if ($this->location->language !== $language) {
+            $location = Location::fromGooglePlaceID($this->location->googlePlaceID, $language);
+            /** @disregard P1014 It's not possible to know the type of `$this` at all */
+            $this->location = $location;
+        }
+
         return [
             'dateCreated' => $this->created_at,
             'dateUpdated' => $this->updated_at,
@@ -28,7 +37,7 @@ class ItemResource extends JsonResource
             'id' => $this->id,
             'images' => ImageResource::collection($this->images),
             'isGiven' => (bool) $this->is_given,
-            'location' => new LocationResource($this->location), // HENDRIK THESE NEED TO BE FOUND FOR A SPECIFIC LANGUAGE, NO?
+            'location' => new LocationResource($this->location),
             'name' => $this->name,
             'tags' => TagResource::collection($this->tags),
             'user' => new UserResource($this->user),

--- a/api/tests/Feature/ItemControllerTest.php
+++ b/api/tests/Feature/ItemControllerTest.php
@@ -145,9 +145,14 @@ class ItemControllerTest extends TestCase
     public function test_mark_as_given()
     {
         $item = Item::inRandomOrder()->first();
+        $location = Location::find($item->location_id);
         $user = User::find($item->user_id);
         $this->actingAs($user);
-        $response = $this->postJson("/items/{$item->id}/mark-as-given");
+        $response = $this->postJson(
+            "/items/{$item->id}/mark-as-given",
+            [],
+            ['Accept-Language' => $location->language],
+        );
         $response->assertStatus(200);
         $this->assertDatabaseHas('items', [
             'id' => $item->id,
@@ -190,6 +195,23 @@ class ItemControllerTest extends TestCase
      */
     public function test_search_no_input()
     {
+        $this->mock(GooglePlaces::class, function ($mock) {
+            $googlePlace = [
+                'formatted_address' => str_replace("\n", ' ', $this->faker->address()),
+                'place_id' => (string)$this->faker->randomNumber(5),
+                'geometry' => [
+                    'location' => [
+                        'lat' => $this->faker->latitude(),
+                        'lng' => $this->faker->longitude(),
+                    ],
+                ],
+                'name' => $this->faker->city(),
+                'utc_offset' => (string)$this->faker->randomNumber(3, true),
+            ];
+            $mock
+                ->shouldReceive('placeDetails')
+                ->andReturn(['result' => $googlePlace]);
+        });
         $response = $this->getJson('/items/search');
         $response
             ->assertStatus(200)

--- a/api/tests/Feature/ThreadControllerTest.php
+++ b/api/tests/Feature/ThreadControllerTest.php
@@ -6,8 +6,10 @@ use App\Http\Resources\ThreadResource;
 use App\Mail\ThreadCreated;
 use App\Mail\ThreadReplied;
 use App\Models\Item;
+use App\Models\Location;
 use App\Models\Thread;
 use App\Models\User;
+use App\Services\GooglePlaces;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
@@ -34,6 +36,23 @@ class ThreadControllerTest extends TestCase
     {
         $user = User::inRandomOrder()->first();
         $this->actingAs($user);
+        $this->mock(GooglePlaces::class, function ($mock) {
+            $googlePlace = [
+                'formatted_address' => str_replace("\n", ' ', $this->faker->address()),
+                'place_id' => (string)$this->faker->randomNumber(5),
+                'geometry' => [
+                    'location' => [
+                        'lat' => $this->faker->latitude(),
+                        'lng' => $this->faker->longitude(),
+                    ],
+                ],
+                'name' => $this->faker->city(),
+                'utc_offset' => (string)$this->faker->randomNumber(3, true),
+            ];
+            $mock
+                ->shouldReceive('placeDetails')
+                ->andReturn(['result' => $googlePlace]);
+        });
         $response = $this->getJson('/threads');
         $response->assertStatus(200);
         $this->assertGreaterThanOrEqual(1, count($response->json('data')));
@@ -60,7 +79,12 @@ class ThreadControllerTest extends TestCase
         $this->actingAs($user);
         $initialCount = Thread::where(['user_id_receiver' => $user->id])->count();
         $item = Item::inRandomOrder()->first();
-        $response = $this->postJson('/threads', ['item' => $item->id, 'message' => $this->faker->sentence()]);
+        $location = Location::find($item->location_id);
+        $response = $this->postJson(
+            '/threads',
+            ['item' => $item->id, 'message' => $this->faker->sentence()],
+            ['Accept-Language' => $location->language],
+        );
         $response->assertStatus(200);
         $afterCount = Thread::where(['user_id_receiver' => $user->id])->count();
         $this->assertEquals($initialCount + 1, $afterCount);
@@ -73,7 +97,7 @@ class ThreadControllerTest extends TestCase
     public function test_reply_to_thread(): void
     {
         Mail::fake();
-        $thread = Thread::with(['item.images', 'messages.user', 'userGiver', 'userReceiver'])
+        $thread = Thread::with(['item.images', 'item.location', 'messages.user', 'userGiver', 'userReceiver'])
             ->inRandomOrder()
             ->first();
         $user = $thread->userReceiver;
@@ -81,6 +105,7 @@ class ThreadControllerTest extends TestCase
         $response = $this->postJson(
             "/threads/{$thread->id}/reply",
             ['message' => $this->faker->sentence()],
+            ['Accept-Language' => $thread->item->location->language],
         );
         $updatedThread = Thread::with(['item.images', 'messages.user', 'userGiver', 'userReceiver'])
             ->find($thread->id);
@@ -104,12 +129,12 @@ class ThreadControllerTest extends TestCase
     {
         $user = User::inRandomOrder()->first();
         $this->actingAs($user);
-        $thread = Thread::with(['item', 'messages.user', 'userGiver', 'userReceiver'])
+        $thread = Thread::with(['item', 'item.location', 'messages.user', 'userGiver', 'userReceiver'])
             ->where(['user_id_giver' => $user->id])
             ->inRandomOrder()
             ->first();
         $resource = new ThreadResource($thread);
-        $response = $this->getJson("/threads/{$thread->id}");
+        $response = $this->getJson("/threads/{$thread->id}", ['Accept-Language' => $thread->item->location->language]);
         $request = Request::create("/threads/{$thread->id}", 'GET');
         $request->setUserResolver(function () use ($user) {
             return $user;

--- a/api/tests/Feature/UserControllerTest.php
+++ b/api/tests/Feature/UserControllerTest.php
@@ -6,6 +6,7 @@ use App\Http\Resources\UserResource;
 use App\Mail\AccountCreated;
 use Exception;
 use App\Models\User as UserModel;
+use App\Services\GooglePlaces;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Http\Request;
@@ -309,6 +310,23 @@ class UserControllerTest extends TestCase
      */
     public function test_user_items()
     {
+        $this->mock(GooglePlaces::class, function ($mock) {
+            $googlePlace = [
+                'formatted_address' => str_replace("\n", ' ', $this->faker->address()),
+                'place_id' => (string)$this->faker->randomNumber(5),
+                'geometry' => [
+                    'location' => [
+                        'lat' => $this->faker->latitude(),
+                        'lng' => $this->faker->longitude(),
+                    ],
+                ],
+                'name' => $this->faker->city(),
+                'utc_offset' => (string)$this->faker->randomNumber(3, true),
+            ];
+            $mock
+                ->shouldReceive('placeDetails')
+                ->andReturn(['result' => $googlePlace]);
+        });
         $user = UserModel::inRandomOrder()->with(['items'])->first();
         $response = $this->getJson("/users/{$user->id}/items");
         $response->assertStatus(200);


### PR DESCRIPTION
Use the `Accept-Language` header
to fetch the correct _Location_ per _Item_.
This is implemented in the `ItemResource`
so it can be shared by any implementor of an _Item_.