### PR TITLE
feat(client): show user information on item page

### DIFF
--- a/client/src/pages/Item/Giver.tsx
+++ b/client/src/pages/Item/Giver.tsx
@@ -1,0 +1,95 @@
+import ChatIcon from '@mui/icons-material/Chat';
+import Avatar from '@mui/material/Avatar';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemAvatar from '@mui/material/ListItemAvatar';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import l10n from '~/src/l10n';
+import { useAuthentication } from '~/src/providers/Authentication';
+import { Item } from '~/src/types/Item';
+import { threadCreate, user as userURL } from '~/src/urls';
+
+interface GiverProps {
+  item: Item;
+}
+
+const Giver: React.FC<GiverProps> = ({ item }) => {
+  const { user } = useAuthentication();
+  const theme = useTheme();
+  const isMediumUp = useMediaQuery(theme.breakpoints.up('md'));
+
+  const isDisabled = React.useMemo<boolean>(
+    () => user?.id === item.user.id,
+    [item, user],
+  );
+
+  return (
+    <List>
+      <ListItem
+        disablePadding
+        secondaryAction={
+          <React.Fragment>
+            {isMediumUp && (
+              <Button
+                color="secondary"
+                component={Link}
+                data-testid="item__action--thread-create"
+                disabled={isDisabled}
+                startIcon={<ChatIcon />}
+                sx={{ display: { md: 'inline-flex', xs: 'none' } }}
+                to={threadCreate(item.id.toString())}
+                variant="contained"
+              >
+                {l10n.itemContactGiver}
+              </Button>
+            )}
+            {!isMediumUp && (
+              <IconButton
+                color="secondary"
+                component={Link}
+                data-testid="item__action--thread-create"
+                disabled={isDisabled}
+                sx={{ display: { md: 'none', xs: 'flex' } }}
+                to={threadCreate(item.id.toString())}
+              >
+                <ChatIcon />
+              </IconButton>
+            )}
+          </React.Fragment>
+        }
+      >
+        <ListItemButton
+          component={Link}
+          selected
+          to={userURL(item.user.id.toString())}
+        >
+          <ListItemAvatar>
+            <Avatar
+              alt={item.user.name}
+              slotProps={{
+                img: {
+                  referrerPolicy: 'no-referrer',
+                },
+              }}
+              src={item.user.avatar}
+            />
+          </ListItemAvatar>
+          <ListItemText
+            primary={item.user.name}
+            primaryTypographyProps={{ noWrap: true, textOverflow: 'ellipsis' }}
+          />
+        </ListItemButton>
+      </ListItem>
+    </List>
+  );
+};
+
+export default Giver;

--- a/client/src/pages/Item/Item.test.tsx
+++ b/client/src/pages/Item/Item.test.tsx
@@ -65,10 +65,10 @@ describe('When the API call fails', () => {
         );
       });
 
-      test('Does not render the new thread button', () => {
+      test('Disables the new thread button', () => {
         expect(
           wrapper.queryByTestId('item__action--thread-create'),
-        ).not.toBeInTheDocument();
+        ).toHaveAttribute('aria-disabled', 'true');
       });
     });
 
@@ -163,7 +163,10 @@ describe.each<TestCase>([
       .mockClear()
       .mockReturnValueOnce(true) // (prefers-color-scheme: dark)
       .mockReturnValueOnce(large)
-      .mockReturnValueOnce(medium);
+      .mockReturnValueOnce(medium)
+      // This line (below) is for the other `useMediaQueries` calls,
+      // like the on in `<Giver />`. It also has to alternate.
+      .mockReturnValue(large);
     wrapper = render(<Item />, { user: null });
     await waitFor(() => expect(itemGet).toHaveBeenCalledTimes(1));
     await waitFor(() =>

--- a/client/src/pages/Item/Item.tsx
+++ b/client/src/pages/Item/Item.tsx
@@ -1,18 +1,12 @@
-import ChatIcon from '@mui/icons-material/Chat';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
-import CardActions from '@mui/material/CardActions';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 import React from 'react';
-import { Link } from 'react-router-dom';
 
-import l10n from '~/src/l10n';
-import { useAuthentication } from '~/src/providers/Authentication';
 import { Item as ItemType } from '~/src/types/Item';
-import { threadCreate } from '~/src/urls';
 
+import Giver from './Giver';
 import Images from './Images';
 import Tags from './Tags';
 
@@ -20,38 +14,21 @@ interface ItemProps {
   item: ItemType;
 }
 
-const Item: React.FC<ItemProps> = ({ item }) => {
-  const { user } = useAuthentication();
-
-  return (
-    <React.Fragment>
-      <Box marginBottom={2}>
-        <Images item={item} />
-      </Box>
-      <Card>
-        <CardContent>
-          <Box marginBottom={2}>
-            <Tags item={item} />
-          </Box>
-          <Typography>{item.description}</Typography>
-        </CardContent>
-        {user?.id !== item.user.id && (
-          <CardActions>
-            <Button
-              color="primary"
-              component={Link}
-              data-testid="item__action--thread-create"
-              startIcon={<ChatIcon />}
-              to={threadCreate(item.id.toString())}
-              variant="contained"
-            >
-              {l10n.itemContactGiver}
-            </Button>
-          </CardActions>
-        )}
-      </Card>
-    </React.Fragment>
-  );
-};
+const Item: React.FC<ItemProps> = ({ item }) => (
+  <React.Fragment>
+    <Box marginBottom={2}>
+      <Images item={item} />
+    </Box>
+    <Card>
+      <CardContent>
+        <Box marginBottom={2}>
+          <Tags item={item} />
+        </Box>
+        <Typography>{item.description}</Typography>
+      </CardContent>
+    </Card>
+    <Giver item={item} />
+  </React.Fragment>
+);
 
 export default Item;


### PR DESCRIPTION
Related to #102 

* Show user information on item page.
* Show "contect giver" button on user information card.
  * Render separate "contact giver" buttons per screen size.